### PR TITLE
Fix problem in TenantConfigProvisioner.prependTenantPath

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "2.1.10"//detectSemVersion()
+version = "2.1.11"//detectSemVersion()
 logger.lifecycle("Project  version: $version")
 
 String detectSemVersion() {

--- a/xm-commons-tenant-endpoint/build.gradle
+++ b/xm-commons-tenant-endpoint/build.gradle
@@ -33,6 +33,8 @@ dependencies {
         exclude module: 'spring-boot-starter-tomcat'
     }
 
+    compile "commons-io:commons-io:${versions.commonsIo}"
+
     testCompile 'junit:junit'
     testCompile "org.mockito:mockito-core"
 }

--- a/xm-commons-tenant-endpoint/src/main/java/com/icthh/xm/commons/tenantendpoint/provisioner/TenantConfigProvisioner.java
+++ b/xm-commons-tenant-endpoint/src/main/java/com/icthh/xm/commons/tenantendpoint/provisioner/TenantConfigProvisioner.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.Singular;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +30,7 @@ public class TenantConfigProvisioner implements TenantProvisioner {
     private final TenantConfigRepository tenantConfigRepository;
 
     public static String prependTenantPath(String path) {
-        return Paths.get(TenantConfigRepository.PATH_CONFIG_TENANT, path).toString();
+        return FilenameUtils.separatorsToUnix(Paths.get(TenantConfigRepository.PATH_CONFIG_TENANT, path).toString());
     }
 
     @Override

--- a/xm-commons-tenant-endpoint/src/test/java/com/icthh/xm/commons/tenantendpoint/provisioner/TenantConfigProvisionerUnitTest.java
+++ b/xm-commons-tenant-endpoint/src/test/java/com/icthh/xm/commons/tenantendpoint/provisioner/TenantConfigProvisionerUnitTest.java
@@ -45,6 +45,11 @@ public class TenantConfigProvisionerUnitTest {
         assertEquals("/config/tenants/{tenantName}/file4.txt", prependTenantPath("file4.txt"));
         assertEquals("/config/tenants/{tenantName}", prependTenantPath(""));
         assertEquals("/config/tenants/{tenantName}", prependTenantPath("/"));
+        //Several cases to cover possible problems with prepend tenant Path (for classpath resources) when system running on WindowsOS
+        assertEquals("/config/tenants/{tenantName}/uaa/emails/en/activationEmail.ftl", prependTenantPath("uaa\\emails\\en\\activationEmail.ftl"));
+        assertEquals("/config/tenants/{tenantName}/uaa/emails/en/creationEmail.ftl", prependTenantPath("uaa\\emails\\en\\creationEmail.ftl"));
+        assertEquals("/config/tenants/{tenantName}/uaa/emails/en/passwordResetEmail.ftl", prependTenantPath("uaa\\emails\\en\\passwordResetEmail.ftl"));
+        assertEquals("/config/tenants/{tenantName}/uaa/emails/en/socialRegistrationValidationEmail.ftl", prependTenantPath("uaa\\emails\\en\\socialRegistrationValidationEmail.ftl"));
     }
 
     @Test


### PR DESCRIPTION
Fixes for problem which was occured in  TenantConfigProvisioner.prependTenantPath when system worked under WindowsOS. 