### PR TITLE
Config cache

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "2.1.17"//detectSemVersion()
+version = "2.1.18"//detectSemVersion()
 logger.lifecycle("Project  version: $version")
 
 String detectSemVersion() {

--- a/xm-commons-config/src/main/java/com/icthh/xm/commons/config/client/service/ConfigCacheFactory.java
+++ b/xm-commons-config/src/main/java/com/icthh/xm/commons/config/client/service/ConfigCacheFactory.java
@@ -1,0 +1,71 @@
+package com.icthh.xm.commons.config.client.service;
+
+import com.icthh.xm.commons.config.client.api.RefreshableConfiguration;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toList;
+
+@Service
+public class ConfigCacheFactory implements RefreshableConfiguration {
+
+    private final Map<Class<? extends RefreshableConfiguration>, RefreshableConfiguration> refreshableConfigurations;
+    private final List<ConfigCache<?>> caches = new ArrayList<>();
+
+    public ConfigCacheFactory(List<RefreshableConfiguration> refreshableConfigurationList) {
+        Map<Class<? extends RefreshableConfiguration>, RefreshableConfiguration> refreshableConfigurations = new HashMap<>();
+        refreshableConfigurationList.forEach(it -> refreshableConfigurations.put(it.getClass(), it));
+        this.refreshableConfigurations = unmodifiableMap(refreshableConfigurations);
+    }
+
+    @Override
+    public void onRefresh(String updatedKey, String config) {
+        caches.forEach(it -> it.updateConfig(updatedKey));
+    }
+
+    @Override
+    public boolean isListeningConfiguration(String updatedKey) {
+        return true;
+    }
+
+    @Override
+    public void onInit(String configKey, String configValue) {
+        onRefresh(configKey, configValue);
+    }
+
+    public <T> ConfigCache<T> create(List<Class<? extends RefreshableConfiguration>> depends) {
+        List<RefreshableConfiguration> configurations = depends.stream().map(refreshableConfigurations::get).collect(toList());
+        ConfigCache<T> cache = new ConfigCache<>(configurations);
+        caches.add(cache);
+        return cache;
+    }
+
+    @AllArgsConstructor
+    public static class ConfigCache<T> {
+        private final List<RefreshableConfiguration> depends;
+        private final Map<String, T> cache = new ConcurrentHashMap<>();
+
+        public void updateConfig(String updatedKey) {
+            boolean isDepends = depends.stream().anyMatch(it -> it.isListeningConfiguration(updatedKey));
+            if (isDepends) {
+                invalidate();
+            }
+        }
+
+        public void invalidate() {
+            cache.clear();
+        }
+
+        public T withCache(String key, Supplier<T> calculation) {
+            return cache.computeIfAbsent(key, k -> calculation.get());
+        }
+    }
+}

--- a/xm-commons-config/src/test/java/com/icthh/xm/commons/config/client/service/ConfigCacheTest.java
+++ b/xm-commons-config/src/test/java/com/icthh/xm/commons/config/client/service/ConfigCacheTest.java
@@ -1,0 +1,53 @@
+package com.icthh.xm.commons.config.client.service;
+
+import com.icthh.xm.commons.config.client.api.RefreshableConfiguration;
+import com.icthh.xm.commons.config.client.service.ConfigCacheFactory.ConfigCache;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.function.Supplier;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ConfigCacheTest {
+
+    private Supplier<String> mockFunction = mock(Supplier.class);
+    private RefreshableConfiguration refreshableConfiguration = mock(RefreshableConfiguration.class);
+    private ConfigCacheFactory factory = new ConfigCacheFactory(singletonList(refreshableConfiguration));
+
+    @Test
+    public void cacheConfigTest() {
+        ConfigCache<String> configCache = factory.create(singletonList(refreshableConfiguration.getClass()));
+        when(mockFunction.get()).thenReturn("mockValue");
+        assertEquals("mockValue", configCache.withCache("test", () -> mockFunction.get()));
+        assertEquals("mockValue", configCache.withCache("test", () -> mockFunction.get()));
+        verify(mockFunction).get();
+    }
+
+    @Test
+    public void cacheConfigUpdateConfigTest() {
+        when(refreshableConfiguration.isListeningConfiguration("mockKey")).thenReturn(true);
+        ConfigCache<String> configCache = factory.create(singletonList(refreshableConfiguration.getClass()));
+        when(mockFunction.get()).thenReturn("mockValue");
+        assertEquals("mockValue", configCache.withCache("test", () -> mockFunction.get()));
+        assertEquals("mockValue", configCache.withCache("test", () -> mockFunction.get()));
+        factory.onRefresh("mockKey", "mockConfig");
+        assertEquals("mockValue", configCache.withCache("test", () -> mockFunction.get()));
+        verify(mockFunction, times(2)).get();
+    }
+
+    @Test
+    public void cacheConfigWithDifferentKeysConfigTest() {
+        ConfigCache<String> configCache = factory.create(singletonList(refreshableConfiguration.getClass()));
+        when(mockFunction.get()).thenReturn("mockValue");
+        assertEquals("mockValue", configCache.withCache("test", () -> mockFunction.get()));
+        assertEquals("mockValue", configCache.withCache("test1", () -> mockFunction.get()));
+        verify(mockFunction, times(2)).get();
+    }
+}


### PR DESCRIPTION
Usage 

```
@Autowire
CommonConfigService commonConfigService;

ConfigCache configCache = commonConfigService.create(Arrays.asList(XmEntitySpecService.class));

configCache.withCache("KEY", () -> {
  return havy computation
})
```

