### PR TITLE
Revert adding application name to classpath.

### DIFF
--- a/xm-commons-lep/src/main/java/com/icthh/xm/commons/lep/TenantScriptStorage.java
+++ b/xm-commons-lep/src/main/java/com/icthh/xm/commons/lep/TenantScriptStorage.java
@@ -88,7 +88,7 @@ public enum TenantScriptStorage {
         } else if (path.startsWith(URL_PREFIX_COMMONS_TENANT)) {
             return new Details(singletonList(tenantKey.toLowerCase()), path.substring(URL_PREFIX_COMMONS_TENANT.length()));
         } else {
-            return new Details(asList(tenantKey.toLowerCase(), appName), path);
+            return new Details(singletonList(tenantKey.toLowerCase()), path);
         }
     }
 

--- a/xm-commons-lep/src/test/java/com/icthh/xm/commons/lep/TenantScriptStorageUnitTest.java
+++ b/xm-commons-lep/src/test/java/com/icthh/xm/commons/lep/TenantScriptStorageUnitTest.java
@@ -24,7 +24,7 @@ public class TenantScriptStorageUnitTest {
 
         assertEquals("classpath:/lep/custom/commons/functions/aggregation", envLepPath);
         assertEquals("classpath:/lep/custom/xm/commons/functions/aggregation", tenantLepPath);
-        assertEquals("classpath:/lep/custom/xm/activation/commons/functions/aggregation", localLepPath);
+        assertEquals("classpath:/lep/custom/xm/commons/functions/aggregation", localLepPath);
     }
 
     @Test


### PR DESCRIPTION
Reasoning: if it is a commons folder under some application, that means that we are already in this application's resources folder. If we add appName, that will result in having appName twice in path.