### PR TITLE
Introduce new PermissionMappingService class which allows to customiz…

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "2.1.30"//detectSemVersion()
+version = "2.1.31"//detectSemVersion()
 logger.lifecycle("Project  version: $version")
 
 String detectSemVersion() {

--- a/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/domain/mapper/PermissionMapper.java
+++ b/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/domain/mapper/PermissionMapper.java
@@ -47,7 +47,9 @@ public class PermissionMapper {
      *
      * @param yml string
      * @return permissions map
+     * @deprecated use {@link com.icthh.xm.commons.permission.service.PermissionMappingService#ymlToPermissions}
      */
+    @Deprecated(forRemoval = true)
     public Map<String, Permission> ymlToPermissions(String yml) {
         return ymlToPermissions(yml, null);
     }
@@ -59,7 +61,9 @@ public class PermissionMapper {
      * @param yml    string
      * @param msName service name
      * @return permissions map
+     * @deprecated use {@link com.icthh.xm.commons.permission.service.PermissionMappingService#ymlToPermissions}
      */
+    @Deprecated(forRemoval = true)
     public Map<String, Permission> ymlToPermissions(String yml, String msName) {
         Map<String, Permission> result = new TreeMap<>();
         try {

--- a/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/service/PermissionMappingService.java
+++ b/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/service/PermissionMappingService.java
@@ -1,0 +1,78 @@
+package com.icthh.xm.commons.permission.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.icthh.xm.commons.logging.LoggingAspectConfig;
+import com.icthh.xm.commons.permission.domain.Permission;
+import com.icthh.xm.commons.permission.service.filter.PermissionMsNameFilter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PermissionMappingService {
+
+    private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    private final PermissionMsNameFilter permissionMsNameFilter;
+
+    @LoggingAspectConfig(inputDetails = false, resultDetails = false)
+    public Map<String, Permission> ymlToPermissions(String yml) {
+        Map<String, Permission> result = new TreeMap<>();
+        try {
+            Map<String, Map<String, Set<Permission>>> permissionMap = deserializeYml(yml);
+            permissionMap.entrySet().stream()
+                .filter(entry -> permissionMsNameFilter.filterPermission(entry.getKey()))
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> entry.getValue()
+                    .forEach((roleKey, permissions) ->
+                        permissions.forEach(permission -> {
+                            permission.setMsName(entry.getKey());
+                            permission.setRoleKey(roleKey);
+                            result.put(roleKey + ":" + permission.getPrivilegeKey(), permission);
+                        })
+                    ));
+        } catch (Exception e) {
+            log.error("Failed to create permissions collection from YML file, error: {}", e.getMessage(), e);
+        }
+        return Collections.unmodifiableMap(result);
+    }
+
+    @LoggingAspectConfig(inputDetails = false, resultDetails = false)
+    public List<Permission> ymlToPermissionsList(String yml) {
+        List<Permission> result = new ArrayList<>();
+        try {
+            Map<String, Map<String, Set<Permission>>> map = deserializeYml(yml);
+            map.entrySet().stream()
+                .filter(entry -> permissionMsNameFilter.filterPermission(entry.getKey()))
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> entry.getValue()
+                    .forEach((roleKey, permissions) ->
+                        permissions.forEach(permission -> {
+                            permission.setMsName(entry.getKey());
+                            permission.setRoleKey(roleKey);
+                            result.add(permission);
+                        })
+                    ));
+
+        } catch (Exception e) {
+            log.error("Failed to create permissions collection from YML file, error: {}", e.getMessage(), e);
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private Map<String, Map<String, Set<Permission>>> deserializeYml(String yml) throws java.io.IOException {
+        return mapper.readValue(yml, new TypeReference<TreeMap<String, TreeMap<String, TreeSet<Permission>>>>() {
+        });
+    }
+}

--- a/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/service/filter/EqualsOrNullPermissionMsNameFilter.java
+++ b/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/service/filter/EqualsOrNullPermissionMsNameFilter.java
@@ -1,0 +1,21 @@
+package com.icthh.xm.commons.permission.service.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnMissingBean(name = "permissionMsNameFilter")
+public class EqualsOrNullPermissionMsNameFilter implements PermissionMsNameFilter {
+
+    @Value("${spring.application.name}")
+    private String msName;
+
+    @Override
+    public boolean filterPermission(String permissionMsName) {
+        return StringUtils.isBlank(msName) || StringUtils.equals(permissionMsName, msName);
+    }
+}

--- a/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/service/filter/PermissionMsNameFilter.java
+++ b/xm-commons-permission/src/main/java/com/icthh/xm/commons/permission/service/filter/PermissionMsNameFilter.java
@@ -1,0 +1,6 @@
+package com.icthh.xm.commons.permission.service.filter;
+
+@FunctionalInterface
+public interface PermissionMsNameFilter {
+    boolean filterPermission(String permissionMsName);
+}

--- a/xm-commons-permission/src/test/java/com/icthh/xm/commons/permission/service/PermissionMappingServiceUnitTest.java
+++ b/xm-commons-permission/src/test/java/com/icthh/xm/commons/permission/service/PermissionMappingServiceUnitTest.java
@@ -1,0 +1,114 @@
+package com.icthh.xm.commons.permission.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import com.icthh.xm.commons.permission.domain.Permission;
+import com.icthh.xm.commons.permission.domain.ReactionStrategy;
+import com.icthh.xm.commons.permission.service.filter.EqualsOrNullPermissionMsNameFilter;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PermissionMappingServiceUnitTest {
+
+    private static final String TEST_YML = "---\n" +
+        "MS1:\n" +
+        "  ROLE1:\n" +
+        "    - privilegeKey: \"PRIVILEGE_KEY1\"\n" +
+        "      disabled: false\n" +
+        "      deleted: false\n" +
+        "      envCondition: \"ENV_COND1\"\n" +
+        "      resourceCondition: \"RESOLUTION_START1\"\n" +
+        "      reactionStrategy: \"SKIP\"\n" +
+        "  ROLE2:\n" +
+        "    - privilegeKey: \"PRIVILEGE_KEY2\"\n" +
+        "      disabled: false\n" +
+        "      deleted: false\n" +
+        "      envCondition: \"ENV_COND2\"\n" +
+        "      resourceCondition: \"RESOLUTION_START2\"\n" +
+        "      reactionStrategy: \"SKIP\"\n" +
+        "MS2:\n" +
+        "  ROLE1:\n" +
+        "    - privilegeKey: \"PRIVILEGE_KEY1\"\n" +
+        "      disabled: false\n" +
+        "      deleted: false\n" +
+        "      envCondition: \"ENV_COND3\"\n" +
+        "      resourceCondition: \"RESOLUTION_START3\"\n" +
+        "      reactionStrategy: \"SKIP\"\n" +
+        "  ROLE3:\n" +
+        "    - privilegeKey: \"PRIVILEGE_KEY3\"\n" +
+        "      disabled: false\n" +
+        "      deleted: false\n" +
+        "      envCondition: \"ENV_COND3\"\n" +
+        "      resourceCondition: \"RESOLUTION_START3\"\n" +
+        "      reactionStrategy: \"SKIP\"\n";
+
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    private PermissionMappingService service;
+
+    private EqualsOrNullPermissionMsNameFilter filter;
+
+    @Before
+    public void setUp() {
+        filter = new EqualsOrNullPermissionMsNameFilter();
+        service = new PermissionMappingService(filter);
+    }
+
+    @Test
+    public void testYmlToPermissions_shouldFilterByMsName() {
+        ReflectionTestUtils.setField(filter, "msName", "MS2", String.class);
+
+        Map<String, Permission> permissions = service.ymlToPermissions(TEST_YML);
+
+        assertThat(permissions).size().isEqualTo(2);
+
+        assertEquals(createPermission(2, 1, 1, 3, 3), permissions.get("ROLE1:PRIVILEGE_KEY1"));
+        assertEquals(createPermission(2, 3, 3, 3, 3), permissions.get("ROLE3:PRIVILEGE_KEY3"));
+    }
+
+    @Test
+    public void testYmlToPermissions_shouldOverrideValue_whenPrivilegesHaveEqualKeys() {
+        Map<String, Permission> permissions = service.ymlToPermissions(TEST_YML);
+
+        assertThat(permissions).size().isEqualTo(3);
+
+        assertEquals(createPermission(1, 2, 2, 2, 2), permissions.get("ROLE2:PRIVILEGE_KEY2"));
+        assertEquals(createPermission(2, 3, 3, 3, 3), permissions.get("ROLE3:PRIVILEGE_KEY3"));
+        // value for key ROLE1:PRIVILEGE_KEY1 is overridden with object from MS2, since we do not perform filtering by ms name
+        assertEquals(createPermission(2, 1, 1, 3, 3), permissions.get("ROLE1:PRIVILEGE_KEY1"));
+    }
+
+    @Test
+    public void testYmlToPermissionsList_shouldReturnAllPermissionsAsList() {
+        List<Permission> permissions = service.ymlToPermissionsList(TEST_YML);
+
+        assertThat(permissions).size().isEqualTo(4);
+
+        assertThat(permissions).contains(createPermission(1, 1, 1, 1, 1));
+        assertThat(permissions).contains(createPermission(1, 2, 2, 2, 2));
+        assertThat(permissions).contains(createPermission(2, 1, 1, 3, 3));
+        assertThat(permissions).contains(createPermission(2, 3, 3, 3, 3));
+    }
+
+    private Permission createPermission(int msNum, int roleNum, int privNum, int condNum, int resNum) {
+        Permission perm = new Permission();
+        perm.setRoleKey("ROLE" + roleNum);
+        perm.setMsName("MS" + msNum);
+        perm.setDisabled(false);
+        perm.setDeleted(false);
+        perm.setEnvCondition(parser.parseExpression("ENV_COND" + condNum));
+        perm.setPrivilegeKey("PRIVILEGE_KEY" + privNum);
+        perm.setReactionStrategy(ReactionStrategy.SKIP);
+        perm.setResourceCondition(parser.parseExpression("RESOLUTION_START" + resNum));
+        return perm;
+    }
+}

--- a/xm-commons-permission/src/test/java/com/icthh/xm/commons/permission/service/mapper/EqualsOrNullPermissionMsNameFilterUnitTest.java
+++ b/xm-commons-permission/src/test/java/com/icthh/xm/commons/permission/service/mapper/EqualsOrNullPermissionMsNameFilterUnitTest.java
@@ -1,0 +1,38 @@
+package com.icthh.xm.commons.permission.service.mapper;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.icthh.xm.commons.permission.service.filter.EqualsOrNullPermissionMsNameFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EqualsOrNullPermissionMsNameFilterUnitTest {
+
+    private EqualsOrNullPermissionMsNameFilter filter;
+    private final static String APP_NAME = "appName";
+
+    @Before
+    public void initPrivilegeScanner() {
+        this.filter = new EqualsOrNullPermissionMsNameFilter();
+    }
+
+    @Test
+    public void testFilterPermission() {
+        assertTrue(filter.filterPermission(null));
+        assertTrue(filter.filterPermission(""));
+        assertTrue(filter.filterPermission("other app name"));
+        assertTrue(filter.filterPermission(APP_NAME));
+
+        ReflectionTestUtils.setField(filter, "msName", APP_NAME, String.class);
+
+        assertFalse(filter.filterPermission(null));
+        assertFalse(filter.filterPermission(""));
+        assertFalse(filter.filterPermission("other app name"));
+        assertTrue(filter.filterPermission(APP_NAME));
+    }
+}


### PR DESCRIPTION
…e permission filtering logic via setting permissionMsNameFilter field

Add new method that allows to collect permissions into list, avoiding unexpected privilege override (map keys did not contain app/ms name and, therefore, could have been overridden if two app/ms had equal role and privilege names)
The service along with EqualsOrNullPermissionMsNameFilter is backward compatible with current implementation of PermissionMapper, which is now marked as deprecated