### PR TITLE
Introduce default rest template for cases when spring load balancer disabled

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "3.2.5"//detectSemVersion()
+version = "3.2.6"//detectSemVersion()
 logger.lifecycle("Project  version: $version")
 
 String detectSemVersion() {

--- a/xm-commons-config/src/main/java/com/icthh/xm/commons/config/client/config/XmRestTemplateConfiguration.java
+++ b/xm-commons-config/src/main/java/com/icthh/xm/commons/config/client/config/XmRestTemplateConfiguration.java
@@ -25,7 +25,6 @@ public class XmRestTemplateConfiguration {
 
     public static final String XM_CONFIG_REST_TEMPLATE = "xm-config-rest-template";
 
-    @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(value = "spring.cloud.loadbalancer.enabled", havingValue = "true", matchIfMissing = true)
     static class XmLoadBalancerRestTemplateConfiguration {
 
@@ -37,7 +36,6 @@ public class XmRestTemplateConfiguration {
         }
     }
 
-    @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(value = "spring.cloud.loadbalancer.enabled", havingValue = "false")
     static class XmPlainRestTemplateConfiguration {
 


### PR DESCRIPTION
Introduce default rest template for cases when spring load balancer disabled

Was added default rest client without spring cloud loadbalancer for cases when on application side spring load balancer explicitly turned off.
These changes is backward compatible. The default rest client without loadbalancer will be created only when load balancing is explicitly disabled: `spring.cloud.loadbalancer.enabled: false` in application properties