### PR TITLE
Add ADMIN role constant and update API access permissions

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "4.2.2"//detectSemVersion()
+version = "4.2.3"//detectSemVersion()
 
 
 logger.lifecycle("Project  version: $version")

--- a/xm-commons-security/src/main/java/com/icthh/xm/commons/security/RoleConstant.java
+++ b/xm-commons-security/src/main/java/com/icthh/xm/commons/security/RoleConstant.java
@@ -6,6 +6,7 @@ package com.icthh.xm.commons.security;
 public final class RoleConstant {
 
     public static final String SUPER_ADMIN = "SUPER-ADMIN";
+    public  static final String ADMIN = "ADMIN";
 
     private RoleConstant() {
     }

--- a/xm-commons-security/src/main/java/com/icthh/xm/commons/security/spring/config/SecurityConfiguration.java
+++ b/xm-commons-security/src/main/java/com/icthh/xm/commons/security/spring/config/SecurityConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 
+import static com.icthh.xm.commons.security.RoleConstant.ADMIN;
 import static com.icthh.xm.commons.security.RoleConstant.SUPER_ADMIN;
 
 @EnableWebSecurity
@@ -78,7 +79,7 @@ public class SecurityConfiguration {
                     .requestMatchers("/management/prometheus").permitAll()
                     .requestMatchers("/management/prometheus/**").permitAll()
                     .requestMatchers("/management/**").hasAuthority(SUPER_ADMIN)
-                    .requestMatchers("/v3/api-docs/**").hasAuthority(SUPER_ADMIN)
+                    .requestMatchers("/v3/api-docs/**").hasAnyAuthority(SUPER_ADMIN, ADMIN)
                     .requestMatchers("/swagger-resources/configuration/ui").permitAll()
             );
         // @formatter:on


### PR DESCRIPTION
## Summary

Add `ADMIN` role constant and extend access to OpenAPI documentation endpoint.

## Root Cause

The `/v3/api-docs/**` endpoint was restricted exclusively to `SUPER-ADMIN`,
preventing regular `ADMIN` users from accessing Swagger/OpenAPI documentation —
even though they legitimately need to explore the API.

## Solution

Added a new role constant:

```java
public static final String ADMIN = "ADMIN";
```

Updated the security rule in `SecurityConfiguration`:

```java
// Before
.requestMatchers("/v3/api-docs/**").hasAuthority(SUPER_ADMIN)

// After
.requestMatchers("/v3/api-docs/**").hasAnyAuthority(SUPER_ADMIN, ADMIN)
```

## Impact

| Role        | Before                        | After                        |
|-------------|-------------------------------|------------------------------|
| SUPER-ADMIN | ✅ Access to `/v3/api-docs/**` | ✅ Access to `/v3/api-docs/**` |
| ADMIN       | ❌ 403 Forbidden               | ✅ Access to `/v3/api-docs/**` |
| Other roles | ❌ 403 Forbidden               | ❌ 403 Forbidden              |

## Conclusion

Safe, minimal change:
- ✅ Grants `ADMIN` role access to OpenAPI docs
- ✅ No changes to existing `SUPER-ADMIN` permissions
- ✅ All other endpoint security rules remain untouched