### PR TITLE
Optimize lep precompilation

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "5.0.20"//detectSemVersion()
+version = "5.0.21"//detectSemVersion()
 
 logger.lifecycle("Project  version: $version")
 

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "5.0.21"//detectSemVersion()
+version = "5.0.20.2"//detectSemVersion()
 
 logger.lifecycle("Project  version: $version")
 

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "5.0.20.2"//detectSemVersion()
+version = "5.0.21"//detectSemVersion()
 
 logger.lifecycle("Project  version: $version")
 

--- a/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyFileParser.java
+++ b/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyFileParser.java
@@ -1,6 +1,9 @@
 package com.icthh.xm.commons.lep.groovy;
 
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -10,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.InnerClassNode;
 import org.codehaus.groovy.control.SourceUnit;
@@ -20,10 +24,36 @@ import org.codehaus.groovy.ast.MethodNode;
 @Slf4j
 public class GroovyFileParser {
 
+    private static final int METADATA_CACHE_MAX_SIZE = 10_000;
+
+    // metadata depends only on the source text, so unchanged files skip the AST parse on engine refresh
+    private final Map<String, GroovyFileMetadata> metadataByContentHash;
+
+    public GroovyFileParser() {
+        this(METADATA_CACHE_MAX_SIZE);
+    }
+
+    public GroovyFileParser(int metadataCacheMaxSize) {
+        this.metadataByContentHash = Collections.synchronizedMap(
+            new LinkedHashMap<>(256, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, GroovyFileMetadata> eldest) {
+                    return size() > metadataCacheMaxSize;
+                }
+            });
+    }
+
     @SneakyThrows
     public GroovyFileMetadata getFileMetaData(String filePath, String source) {
         try {
-            return getGroovyFileMetadata(filePath, source);
+            String contentHash = DigestUtils.sha256Hex(source);
+            GroovyFileMetadata cached = metadataByContentHash.get(contentHash);
+            if (cached != null) {
+                return cached;
+            }
+            GroovyFileMetadata metadata = getGroovyFileMetadata(filePath, source);
+            metadataByContentHash.put(contentHash, metadata);
+            return metadata;
         } catch (Exception e) {
             log.error("Error parsing groovy source: {}", e.getMessage(), e);
             return new GroovyFileMetadata();

--- a/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyLepEngine.java
+++ b/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyLepEngine.java
@@ -2,6 +2,7 @@ package com.icthh.xm.commons.lep.groovy;
 
 import com.icthh.xm.commons.lep.LepPathResolver;
 import com.icthh.xm.commons.lep.ProceedingLep;
+import com.icthh.xm.commons.lep.XmLepConstants;
 import com.icthh.xm.commons.lep.api.BaseLepContext;
 import com.icthh.xm.commons.lep.api.LepEngine;
 import com.icthh.xm.commons.lep.api.LepKey;
@@ -15,6 +16,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -262,7 +264,17 @@ public class GroovyLepEngine extends LepEngine {
 
     @SneakyThrows
     private URLClassLoader buildCachingClassLoader(ClassLoader parent, File targetDir) {
-        return new URLClassLoader(new URL[]{targetDir.toURI().toURL()}, parent);
+        List<URL> urls = new ArrayList<>();
+        // new distribution layout: classes are packed into a jar next to the compiled directory,
+        // URLClassLoader reads them directly from the jar without unpacking the class tree
+        File compiledJar = new File(targetDir.getParentFile(), XmLepConstants.SCRIPT_COMPILED_JAR);
+        if (compiledJar.isFile()) {
+            urls.add(compiledJar.toURI().toURL());
+        }
+        // the directory stays on the classpath: old layout distributions keep classes there,
+        // and it is the target directory for classes compiled at runtime
+        urls.add(targetDir.toURI().toURL());
+        return new URLClassLoader(urls.toArray(new URL[0]), parent);
     }
 
     @SneakyThrows

--- a/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyLepEngine.java
+++ b/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyLepEngine.java
@@ -132,7 +132,8 @@ public class GroovyLepEngine extends LepEngine {
 
         this.leps.forEach(lep -> {
             try {
-                if (isCommonsClass(lep.getPath()) || !isScript(lep)) {
+                boolean isWarmupByCompilation = !isCommonsClass(lep.getPath()) && isScript(lep);
+                if (!useDirectoryCompiledSources && !isWarmupByCompilation) {
                     return;
                 }
 
@@ -140,6 +141,11 @@ public class GroovyLepEngine extends LepEngine {
                 log.info("START | Warmup lep {}", lep.getPath());
 
                 if (useDirectoryCompiledSources && tryLoadCompiled(groovyClassLoader, lep, warmUpTime)) {
+                    return;
+                }
+
+                if (!isWarmupByCompilation) {
+                    // no precompiled class: commons and class files are compiled on demand
                     return;
                 }
 

--- a/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyLepEngineConfiguration.java
+++ b/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/GroovyLepEngineConfiguration.java
@@ -77,7 +77,9 @@ public class GroovyLepEngineConfiguration extends LepSpringConfiguration {
             lepPathResolver,
             groovyFileParser,
             warmupScripts ? tenantsWithLepWarmup : emptySet(),
-            warmupScriptsForAllTenant,
+            // in precompiled mode warmup is cheap (no compilation), and skipping it moves
+            // the classloading + metaclass cost to the first request after every refresh
+            warmupScripts && (warmupScriptsForAllTenant || Boolean.TRUE.equals(precompiledMode)),
             precompiledMode,
             pathToWorkingDirectory
         );

--- a/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/LepCompiler.java
+++ b/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/LepCompiler.java
@@ -170,6 +170,9 @@ public class LepCompiler {
             String tenant = entry.getKey();
             Path compiledDir = workDir.resolve(tenant).resolve(XmLepConstants.SCRIPT_COMPILED_DIR);
             Files.createDirectories(compiledDir);
+            // a leftover jar from an interrupted run would be picked up by the warmup instead of
+            // recompiling, and then overwritten with an incomplete one - always compile from scratch
+            Files.deleteIfExists(compiledDir.resolveSibling(XmLepConstants.SCRIPT_COMPILED_JAR));
 
             log.info("Compiling LEPs for tenant [{}] → {}", tenant, compiledDir);
 
@@ -189,7 +192,40 @@ public class LepCompiler {
             factory.setBeanClassLoader(Thread.currentThread().getContextClassLoader());
 
             factory.createLepEngine(tenant, entry.getValue());
+
+            packCompiledClassesToJar(compiledDir);
         }
+    }
+
+    /**
+     * Packs the compiled class tree into a single jar, so the distribution zip contains one
+     * entry per tenant instead of tens of thousands of class files (unzip on refresh becomes
+     * a single sequential copy, and URLClassLoader mounts the jar directly).
+     */
+    private static void packCompiledClassesToJar(Path compiledDir) throws IOException {
+        Path jarFile = compiledDir.resolveSibling(XmLepConstants.SCRIPT_COMPILED_JAR);
+
+        try (
+            ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(jarFile.toFile()));
+            Stream<Path> files = Files.walk(compiledDir)
+        ) {
+            // jar must have at least one entry, so the root directory entry is always added
+            zos.putNextEntry(new ZipEntry("META-INF/"));
+            zos.closeEntry();
+
+            files.filter(Files::isRegularFile).forEach(file -> {
+                try {
+                    String entryName = compiledDir.relativize(file).toString().replace('\\', '/');
+                    zos.putNextEntry(new ZipEntry(entryName));
+                    zos.write(Files.readAllBytes(file));
+                    zos.closeEntry();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+
+        FileUtils.deleteDirectory(compiledDir.toFile());
     }
 
     private static void zipDirectory(Path sourceDir, String outputPath) throws IOException {

--- a/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/XmLepPrecompiledConfigLoader.java
+++ b/xm-commons-lep-groovy/src/main/java/com/icthh/xm/commons/lep/groovy/XmLepPrecompiledConfigLoader.java
@@ -47,6 +47,7 @@ public class XmLepPrecompiledConfigLoader implements RefreshableConfiguration {
     private final ObjectMapper ymlMapper = YamlMapperUtils.yamlDefaultMapper();
 
     private final Map<String, XmLepPrecompiledConfig> precompiledConfigsByTenant = new ConcurrentHashMap<>();
+    private final Map<String, String> appliedZipStateByTenant = new ConcurrentHashMap<>();
 
     public XmLepPrecompiledConfigLoader(LepRefreshService lepRefreshService,
                                         String appName,
@@ -66,6 +67,7 @@ public class XmLepPrecompiledConfigLoader implements RefreshableConfiguration {
                 precompiledConfigsByTenant.put(tenant, precompiledConfig);
             } else {
                 precompiledConfigsByTenant.remove(tenant);
+                appliedZipStateByTenant.remove(tenant);
             }
         } catch (Exception e) {
             log.error("Error update configuration by key: {}", updatedKey, e);
@@ -105,6 +107,14 @@ public class XmLepPrecompiledConfigLoader implements RefreshableConfiguration {
 
     protected void fetchZip(String zipPath, List<String> tenants) {
         String fileHash = hashFile(zipPath);
+        // the state is per tenant: comparing by zip path is not enough, because after a path
+        // switch A -> B -> A the zip at A is unchanged while the engines are built from B
+        String zipState = zipPath + "|" + fileHash;
+        if (tenants.stream().allMatch(tenant -> zipState.equals(appliedZipStateByTenant.get(tenant)))) {
+            log.info("Skip lep engines refresh: zip [{}] content unchanged for tenants {}", zipPath, tenants);
+            return;
+        }
+
         Path tempDir = pathToWorkingDirectory.resolve(fileHash);
 
         try {
@@ -124,6 +134,7 @@ public class XmLepPrecompiledConfigLoader implements RefreshableConfiguration {
 
             log.info("Refreshing LEP engines for tenants {} from version {}", sourcesByTenant.keySet(), currentVersion);
             lepRefreshService.initOrRefresh(sourcesByTenant.keySet(), sourcesByTenant, versionedDir.toAbsolutePath().toString());
+            sourcesByTenant.keySet().forEach(tenant -> appliedZipStateByTenant.put(tenant, zipState));
 
         } catch (IOException e) {
             log.error("Failed to process zip [{}] for tenants {}", zipPath, tenants, e);

--- a/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/GroovyPrecompiledWarmupIntTest.java
+++ b/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/GroovyPrecompiledWarmupIntTest.java
@@ -9,9 +9,16 @@ import com.icthh.xm.commons.lep.groovy.config.LepCompilerConfiguration;
 import com.icthh.xm.commons.lep.groovy.storage.LepStorageFactory;
 import com.icthh.xm.commons.lep.impl.LoggingWrapper;
 import com.icthh.xm.commons.lep.spring.ApplicationNameProvider;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +91,50 @@ public class GroovyPrecompiledWarmupIntTest {
             "script class expected to be warmed up from precompiled sources");
         assertTrue(hasPrecompiledLog(COMMONS_PATH),
             "commons class expected to be warmed up from precompiled sources");
+    }
+
+    @Test
+    void warmupLoadsClassesFromCompiledJar() throws Exception {
+        List<XmLepConfigFile> leps = List.of(
+            new XmLepConfigFile(COMMONS_PATH,
+                "package WARMTEST.testApp.lep.commons\nclass WarmService { def hello() { return 'ok' } }\n"),
+            new XmLepConfigFile(SCRIPT_PATH,
+                "import WARMTEST.testApp.lep.commons.WarmService\nreturn new WarmService().hello()\n")
+        );
+
+        Path compiledDir = tempDir.resolve("compiled");
+
+        // phase A: precompile into the directory, then pack it into compiled.jar like LepCompiler does
+        createFactory(compiledDir.toAbsolutePath().toString()).createLepEngine(TENANT, leps);
+        packToJar(compiledDir, tempDir.resolve("compiled.jar"));
+        FileUtils.deleteDirectory(compiledDir.toFile());
+
+        logAppender.list.clear();
+
+        // phase B: no class tree on disk - warmup must load precompiled classes from compiled.jar
+        createFactory(compiledDir.toAbsolutePath().toString()).createLepEngine(TENANT, leps);
+
+        assertTrue(hasPrecompiledLog(SCRIPT_PATH),
+            "script class expected to be loaded from compiled.jar");
+        assertTrue(hasPrecompiledLog(COMMONS_PATH),
+            "commons class expected to be loaded from compiled.jar");
+    }
+
+    private static void packToJar(Path dir, Path jar) throws Exception {
+        try (
+            ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jar));
+            Stream<Path> files = Files.walk(dir)
+        ) {
+            files.filter(Files::isRegularFile).forEach(file -> {
+                try {
+                    zos.putNextEntry(new ZipEntry(dir.relativize(file).toString().replace('\\', '/')));
+                    zos.write(Files.readAllBytes(file));
+                    zos.closeEntry();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
     }
 
     private boolean hasPrecompiledLog(String configPath) {

--- a/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/GroovyPrecompiledWarmupIntTest.java
+++ b/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/GroovyPrecompiledWarmupIntTest.java
@@ -1,0 +1,112 @@
+package com.icthh.xm.commons.lep.groovy;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.icthh.xm.commons.lep.LepPathResolver;
+import com.icthh.xm.commons.lep.api.XmLepConfigFile;
+import com.icthh.xm.commons.lep.groovy.config.LepCompilerConfiguration;
+import com.icthh.xm.commons.lep.groovy.storage.LepStorageFactory;
+import com.icthh.xm.commons.lep.impl.LoggingWrapper;
+import com.icthh.xm.commons.lep.spring.ApplicationNameProvider;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringJUnitConfig(LepCompilerConfiguration.class)
+@ActiveProfiles("export")
+@TestPropertySource(properties = "spring.application.name=testApp")
+public class GroovyPrecompiledWarmupIntTest {
+
+    private static final String TENANT = "WARMTEST";
+    private static final String COMMONS_PATH = "/config/tenants/WARMTEST/testApp/lep/commons/WarmService.groovy";
+    private static final String SCRIPT_PATH = "/config/tenants/WARMTEST/testApp/lep/service/Do$$around.groovy";
+
+    @Autowired
+    private ApplicationNameProvider applicationNameProvider;
+    @Autowired
+    private LepStorageFactory lepStorageFactory;
+    @Autowired
+    private LoggingWrapper loggingWrapper;
+    @Autowired
+    private LepPathResolver lepPathResolver;
+    @Autowired
+    private GroovyFileParser groovyFileParser;
+
+    @TempDir
+    Path tempDir;
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(GroovyLepEngine.class)).addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ((Logger) LoggerFactory.getLogger(GroovyLepEngine.class)).detachAppender(logAppender);
+    }
+
+    @Test
+    void warmupLoadsPrecompiledCommonsClasses() {
+        List<XmLepConfigFile> leps = List.of(
+            new XmLepConfigFile(COMMONS_PATH,
+                "package WARMTEST.testApp.lep.commons\nclass WarmService { def hello() { return 'ok' } }\n"),
+            new XmLepConfigFile(SCRIPT_PATH,
+                "import WARMTEST.testApp.lep.commons.WarmService\nreturn new WarmService().hello()\n")
+        );
+
+        String compiledDir = tempDir.resolve("compiled").toAbsolutePath().toString();
+
+        // phase A: precompile - the same way LepCompiler produces the zip content
+        createFactory(compiledDir).createLepEngine(TENANT, leps);
+
+        logAppender.list.clear();
+
+        // phase B: fresh engine over the precompiled directory - warmup must load commons classes precompiled
+        createFactory(compiledDir).createLepEngine(TENANT, leps);
+
+        assertTrue(hasPrecompiledLog(SCRIPT_PATH),
+            "script class expected to be warmed up from precompiled sources");
+        assertTrue(hasPrecompiledLog(COMMONS_PATH),
+            "commons class expected to be warmed up from precompiled sources");
+    }
+
+    private boolean hasPrecompiledLog(String configPath) {
+        String lepPath = configPath.replace("/config/tenants/", "").replace(".groovy", "");
+        return logAppender.list.stream()
+            .map(ILoggingEvent::getFormattedMessage)
+            .anyMatch(message -> message.contains("PRECOMPILED") && message.contains(lepPath));
+    }
+
+    private GroovyLepEngineFactory createFactory(String compiledDir) {
+        GroovyLepEngineFactory factory = new GroovyLepEngineFactory(
+            applicationNameProvider.getAppName(),
+            lepStorageFactory,
+            new RecreateGroovyLepEngineOnRefresh(),
+            loggingWrapper,
+            lepPathResolver,
+            groovyFileParser,
+            Set.of(),
+            true,
+            true,
+            compiledDir
+        );
+        factory.setBeanClassLoader(Thread.currentThread().getContextClassLoader());
+        return factory;
+    }
+}

--- a/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/LepCompilerJarLayoutIntTest.java
+++ b/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/LepCompilerJarLayoutIntTest.java
@@ -1,0 +1,122 @@
+package com.icthh.xm.commons.lep.groovy;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LepCompilerJarLayoutIntTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        // LepCompiler boots its own Spring context which reads the app name from the environment
+        System.setProperty("spring.application.name", "testApp");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("spring.application.name");
+    }
+
+    @Test
+    void compiledClassesArePackedIntoJarPerTenant() throws IOException {
+        Path inputZip = tempDir.resolve("config-export.zip");
+        writeZip(inputZip, Map.of(
+            "config/tenants/TEST/testApp/lep/service/Save$$around.groovy", "return 'compiled'"
+        ));
+        Path outputDir = Files.createDirectories(tempDir.resolve("output"));
+
+        new LepCompiler().execute(new String[]{inputZip.toString(), outputDir.toString()});
+
+        Path outputZip = outputDir.resolve("testApp-compiled-lep.zip");
+        assertTrue(Files.exists(outputZip), "compiled lep zip expected");
+
+        Map<String, byte[]> entries = readZip(outputZip);
+
+        assertTrue(entries.containsKey("TEST/compiled.jar"),
+            "compiled classes expected to be packed as TEST/compiled.jar");
+        assertFalse(entries.keySet().stream().anyMatch(k -> k.startsWith("TEST/compiled/")),
+            "no unpacked class tree expected under TEST/compiled/");
+        assertTrue(entries.keySet().stream()
+                .anyMatch(k -> k.startsWith("TEST/sources/") && k.endsWith("Save$$around.groovy")),
+            "sources expected to stay unpacked");
+
+        Map<String, byte[]> jarEntries = readZip(entries.get("TEST/compiled.jar"));
+        assertTrue(jarEntries.keySet().stream().anyMatch(k -> k.endsWith(".class")),
+            "compiled.jar expected to contain class files");
+    }
+
+    @Test
+    void recompilationIntoDirtyOutputDirKeepsClassesInJar() throws IOException {
+        Path inputZip = tempDir.resolve("config-export.zip");
+        writeZip(inputZip, Map.of(
+            "config/tenants/TEST/testApp/lep/service/Save$$around.groovy", "return 'compiled'"
+        ));
+        Path outputDir = Files.createDirectories(tempDir.resolve("output"));
+
+        new LepCompiler().execute(new String[]{inputZip.toString(), outputDir.toString()});
+
+        // simulate an interrupted previous run: compiled.jar left on disk from the first pass
+        Map<String, byte[]> firstRun = readZip(outputDir.resolve("testApp-compiled-lep.zip"));
+        Path leftoverJar = outputDir.resolve("TEST").resolve("compiled.jar");
+        Files.createDirectories(leftoverJar.getParent());
+        Files.write(leftoverJar, firstRun.get("TEST/compiled.jar"));
+
+        // second run into the dirty output dir must not lose compiled classes
+        new LepCompiler().execute(new String[]{inputZip.toString(), outputDir.toString()});
+
+        Map<String, byte[]> entries = readZip(outputDir.resolve("testApp-compiled-lep.zip"));
+        Map<String, byte[]> jarEntries = readZip(entries.get("TEST/compiled.jar"));
+        assertTrue(jarEntries.keySet().stream().anyMatch(k -> k.contains("Save") && k.endsWith(".class")),
+            "compiled.jar expected to still contain the lep script class after recompilation, but has: "
+                + jarEntries.keySet());
+    }
+
+    private static void writeZip(Path zip, Map<String, String> files) throws IOException {
+        try (OutputStream out = Files.newOutputStream(zip); ZipOutputStream zos = new ZipOutputStream(out)) {
+            for (Map.Entry<String, String> file : files.entrySet()) {
+                zos.putNextEntry(new ZipEntry(file.getKey()));
+                zos.write(file.getValue().getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+    }
+
+    private static Map<String, byte[]> readZip(Path zip) throws IOException {
+        return readZip(new ZipInputStream(Files.newInputStream(zip)));
+    }
+
+    private static Map<String, byte[]> readZip(byte[] content) throws IOException {
+        return readZip(new ZipInputStream(new ByteArrayInputStream(content)));
+    }
+
+    private static Map<String, byte[]> readZip(ZipInputStream zis) throws IOException {
+        Map<String, byte[]> entries = new HashMap<>();
+        try (zis) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (!entry.isDirectory()) {
+                    entries.put(entry.getName(), zis.readAllBytes());
+                }
+            }
+        }
+        return entries;
+    }
+}

--- a/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/XmLepPrecompiledConfigLoaderUnitTest.java
+++ b/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/groovy/XmLepPrecompiledConfigLoaderUnitTest.java
@@ -1,0 +1,163 @@
+package com.icthh.xm.commons.lep.groovy;
+
+import com.icthh.xm.commons.lep.api.XmLepConfigFile;
+import com.icthh.xm.commons.lep.spring.LepRefreshService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class XmLepPrecompiledConfigLoaderUnitTest {
+
+    private static final String CONFIG_KEY = "/config/tenants/TEST/testApp/lep.yml";
+    private static final String SCRIPT_PATH = "TEST/sources/config/tenants/TEST/testApp/lep/service/Script.groovy";
+
+    @TempDir
+    Path tempDir;
+
+    private final AtomicInteger refreshCount = new AtomicInteger();
+
+    private final LepRefreshService refreshService = new LepRefreshService() {
+        @Override
+        public Future<?> refreshEngines(Set<String> tenantsToUpdate,
+                                        Map<String, Map<String, XmLepConfigFile>> scriptsByTenant,
+                                        boolean isInit) {
+            return CompletableFuture.completedFuture(true);
+        }
+
+        @Override
+        public void initOrRefresh(Set<String> tenantsToUpdate,
+                                  Map<String, Map<String, XmLepConfigFile>> scriptsByTenant,
+                                  String pathToPrecompiledLep) {
+            refreshCount.incrementAndGet();
+        }
+    };
+
+    @Test
+    void skipRefreshWhenZipContentUnchanged() throws Exception {
+        Path zip = tempDir.resolve("compiled-lep.zip");
+        writeZip(zip, Map.of(SCRIPT_PATH, "return 'ok'"));
+
+        Path workDir = tempDir.resolve("work");
+        XmLepPrecompiledConfigLoader loader =
+            new XmLepPrecompiledConfigLoader(refreshService, "testApp", workDir.toString());
+
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"" + zip + "\"\n# 1");
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(1, refreshCount.get());
+
+        // lep.yml touched (comment changed) but zip content is the same -> engines must NOT be refreshed
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"" + zip + "\"\n# 2");
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(1, refreshCount.get());
+
+        // zip content changed -> engines must be refreshed
+        writeZip(zip, Map.of(SCRIPT_PATH, "return 'changed'"));
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(2, refreshCount.get());
+    }
+
+    @Test
+    void refreshWhenSamePathHasDifferentZipContent() throws Exception {
+        Path zip = tempDir.resolve("compiled-lep.zip");
+        Path workDir = tempDir.resolve("work");
+        XmLepPrecompiledConfigLoader loader =
+            new XmLepPrecompiledConfigLoader(refreshService, "testApp", workDir.toString());
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"" + zip + "\"");
+
+        // the zip PATH never changes in this test, only the bytes inside it do
+        writeZip(zip, Map.of(SCRIPT_PATH, "return 'v1'"));
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(1, refreshCount.get());
+
+        writeZip(zip, Map.of(SCRIPT_PATH, "return 'v2'"));
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(2, refreshCount.get());
+
+        writeZip(zip, Map.of(SCRIPT_PATH, "return 'v3'"));
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(3, refreshCount.get());
+
+        // unchanged bytes -> skipped
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(3, refreshCount.get());
+    }
+
+    @Test
+    void refreshWhenZipPathSwitchesBackWithSameContent() throws Exception {
+        Path zipA = tempDir.resolve("a.zip");
+        writeZip(zipA, Map.of(SCRIPT_PATH, "return 'a'"));
+        Path zipB = tempDir.resolve("b.zip");
+        writeZip(zipB, Map.of(SCRIPT_PATH, "return 'b'"));
+
+        Path workDir = tempDir.resolve("work");
+        XmLepPrecompiledConfigLoader loader =
+            new XmLepPrecompiledConfigLoader(refreshService, "testApp", workDir.toString());
+
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"" + zipA + "\"");
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(1, refreshCount.get());
+
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"" + zipB + "\"");
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(2, refreshCount.get());
+
+        // switch back to zip A: content of A is unchanged, but engines were built from B,
+        // so the refresh must NOT be skipped
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"" + zipA + "\"");
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(3, refreshCount.get());
+
+        // stable state again -> skipped
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(3, refreshCount.get());
+    }
+
+    @Test
+    void refreshWhenTenantConfigRemovedAndReadded() throws Exception {
+        Path zip = tempDir.resolve("compiled-lep.zip");
+        writeZip(zip, Map.of(SCRIPT_PATH, "return 'ok'"));
+
+        Path workDir = tempDir.resolve("work");
+        XmLepPrecompiledConfigLoader loader =
+            new XmLepPrecompiledConfigLoader(refreshService, "testApp", workDir.toString());
+
+        String config = "pathToPrecompiledLep: \"" + zip + "\"";
+        loader.onRefresh(CONFIG_KEY, config);
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(1, refreshCount.get());
+
+        // tenant precompiled config removed -> applied state must be forgotten
+        loader.onRefresh(CONFIG_KEY, "pathToPrecompiledLep: \"\"");
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(1, refreshCount.get());
+
+        // re-added with the same zip -> engines must be refreshed
+        loader.onRefresh(CONFIG_KEY, config);
+        loader.refreshFinished(List.of(CONFIG_KEY));
+        assertEquals(2, refreshCount.get());
+    }
+
+    private static void writeZip(Path zip, Map<String, String> files) throws Exception {
+        try (OutputStream out = Files.newOutputStream(zip); ZipOutputStream zos = new ZipOutputStream(out)) {
+            for (Map.Entry<String, String> file : files.entrySet()) {
+                zos.putNextEntry(new ZipEntry(file.getKey()));
+                zos.write(file.getValue().getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+    }
+}

--- a/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/spring/GroovyFileParserCacheUnitTest.java
+++ b/xm-commons-lep-groovy/src/test/java/com/icthh/xm/commons/lep/spring/GroovyFileParserCacheUnitTest.java
@@ -1,0 +1,65 @@
+package com.icthh.xm.commons.lep.spring;
+
+import com.icthh.xm.commons.lep.groovy.GroovyFileParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GroovyFileParserCacheUnitTest {
+
+    @Test
+    public void testMetadataCachedByContentHash() {
+        AtomicInteger parseCount = new AtomicInteger();
+        GroovyFileParser gfp = new GroovyFileParser() {
+            @Override
+            public GroovyFileMetadata getGroovyFileMetadata(String filePath, String source) {
+                parseCount.incrementAndGet();
+                return super.getGroovyFileMetadata(filePath, source);
+            }
+        };
+
+        String source = "package TEST.testApp.lep.commons\n"
+            + "class CachedClass {\n static def field = 1\n static def method() {}\n}\n";
+
+        gfp.getFileMetaData("lep/CachedClass.groovy", source);
+        GroovyFileParser.GroovyFileMetadata second = gfp.getFileMetaData("lep/other/CachedClass.groovy", source);
+
+        assertEquals(1, parseCount.get());
+        assertTrue(second.canImport("CachedClass"));
+        assertTrue(second.canImport("CachedClass.field"));
+        assertTrue(second.canImport("CachedClass.method"));
+
+        String changed = source.replace("CachedClass", "ChangedClass");
+        GroovyFileParser.GroovyFileMetadata third = gfp.getFileMetaData("lep/CachedClass.groovy", changed);
+        assertEquals(2, parseCount.get());
+        assertTrue(third.canImport("ChangedClass"));
+    }
+
+    @Test
+    public void testEvictsLeastRecentlyUsedEntriesWhenCacheFull() {
+        AtomicInteger parseCount = new AtomicInteger();
+        GroovyFileParser gfp = new GroovyFileParser(2) {
+            @Override
+            public GroovyFileMetadata getGroovyFileMetadata(String filePath, String source) {
+                parseCount.incrementAndGet();
+                return super.getGroovyFileMetadata(filePath, source);
+            }
+        };
+
+        gfp.getFileMetaData("a.groovy", "return 'a'");
+        gfp.getFileMetaData("b.groovy", "return 'b'");
+        gfp.getFileMetaData("c.groovy", "return 'c'");
+        assertEquals(3, parseCount.get());
+
+        // 'a' was evicted (cache size 2), so it must be parsed again
+        gfp.getFileMetaData("a.groovy", "return 'a'");
+        assertEquals(4, parseCount.get());
+
+        // 'c' is still cached
+        gfp.getFileMetaData("c.groovy", "return 'c'");
+        assertEquals(4, parseCount.get());
+    }
+}

--- a/xm-commons-lep/src/main/java/com/icthh/xm/commons/lep/XmLepConstants.java
+++ b/xm-commons-lep/src/main/java/com/icthh/xm/commons/lep/XmLepConstants.java
@@ -53,6 +53,11 @@ public final class XmLepConstants {
      */
     public static final String SCRIPT_COMPILED_DIR = "compiled";
 
+    /**
+     * Jar file name with compiled lep classes inside the precompiled distribution.
+     */
+    public static final String SCRIPT_COMPILED_JAR = "compiled.jar";
+
     private XmLepConstants() {
         throw new UnsupportedOperationException("Prevent creation for constructor utils class");
     }

--- a/xm-commons-lep/src/main/java/com/icthh/xm/commons/lep/impl/engine/LepManagementServiceImpl.java
+++ b/xm-commons-lep/src/main/java/com/icthh/xm/commons/lep/impl/engine/LepManagementServiceImpl.java
@@ -10,9 +10,12 @@ import com.icthh.xm.commons.lep.api.LepKey;
 import com.icthh.xm.commons.lep.api.LepManagementService;
 import com.icthh.xm.commons.lep.api.XmLepConfigFile;
 import com.icthh.xm.commons.tenant.TenantContextHolder;
+import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 
@@ -94,11 +97,30 @@ public class LepManagementServiceImpl implements LepManagementService {
     }
 
     private List<LepEngine> createEnginesPrecompiledPath(String tenantKey, List<XmLepConfigFile> tenantConfigs, String pathToPrecompiledLep) {
-        String compiledPath = Path.of(pathToPrecompiledLep).resolve(tenantKey).resolve(XmLepConstants.SCRIPT_COMPILED_DIR).toString();
+        Path versionedDir = Path.of(pathToPrecompiledLep);
+        Path tenantDir = versionedDir.resolve(tenantKey);
+        String compiledPath = tenantDir.resolve(XmLepConstants.SCRIPT_COMPILED_DIR).toString();
         return engineFactories.stream()
             .map(it -> it.createLepEngine(tenantKey, tenantConfigs, compiledPath))
+            // classes are loaded lazily for the whole engine lifetime, so the version directory
+            // is deleted exactly when the engine built from it is destroyed (on engines replace)
+            .peek(engine -> engine.addDestroyCallback(destroyed -> deletePrecompiledDir(tenantDir, versionedDir)))
             .sorted(comparingInt(LepEngine::order))
             .toList();
+    }
+
+    private static void deletePrecompiledDir(Path tenantDir, Path versionedDir) {
+        if (!Files.exists(tenantDir)) {
+            return;
+        }
+        log.info("Delete precompiled lep directory {} of the destroyed engine", tenantDir);
+        if (!FileUtils.deleteQuietly(tenantDir.toFile())) {
+            log.warn("Failed to delete precompiled lep directory {}", tenantDir);
+        }
+        File[] leftInVersionedDir = versionedDir.toFile().listFiles();
+        if (leftInVersionedDir != null && leftInVersionedDir.length == 0) {
+            FileUtils.deleteQuietly(versionedDir.toFile());
+        }
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Groovy script handling with metadata caching to reduce repeated parsing.
  * Optimized precompiled LEP warmup and class loading, including jar-based compiled outputs.
  * Engine refresh is now skipped when the precompiled ZIP content hasn’t changed.

* **Bug Fixes**
  * Corrected warmup behavior so only the intended entries are processed.
  * Prevents warmup from reusing stale/partial compiled artifacts and reliably resets behavior when tenant config is removed and re-added.

* **Tests**
  * Added unit and integration tests covering caching, refresh skipping logic, and precompiled jar layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->