### PR TITLE
Add security masking logging appender

### DIFF
--- a/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/MaskedLoggingEvent.java
+++ b/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/MaskedLoggingEvent.java
@@ -1,0 +1,120 @@
+package com.icthh.xm.commons.logging.aop;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
+
+import java.util.List;
+import java.util.Map;
+
+public class MaskedLoggingEvent implements ILoggingEvent {
+
+    private final ILoggingEvent delegate;
+    private final String maskedMessage;
+
+    public MaskedLoggingEvent(ILoggingEvent delegate, String maskedMessage) {
+        this.delegate = delegate;
+        this.maskedMessage = maskedMessage;
+    }
+
+    @Override
+    public String getThreadName() {
+        return delegate.getThreadName();
+    }
+
+    @Override
+    public Level getLevel() {
+        return delegate.getLevel();
+    }
+
+    @Override
+    public String getMessage() {
+        return maskedMessage;
+    }
+
+    @Override
+    public Object[] getArgumentArray() {
+        // повертаємо пустий масив, щоб енкодери не пробували форматувати старі аргументи
+        return new Object[0];
+    }
+
+    @Override
+    public String getFormattedMessage() {
+        return maskedMessage;
+    }
+
+    @Override
+    public String getLoggerName() {
+        return delegate.getLoggerName();
+    }
+
+    @Override
+    public LoggerContextVO getLoggerContextVO() {
+        return delegate.getLoggerContextVO();
+    }
+
+    @Override
+    public IThrowableProxy getThrowableProxy() {
+        return delegate.getThrowableProxy();
+    }
+
+    @Override
+    public StackTraceElement[] getCallerData() {
+        return delegate.getCallerData();
+    }
+
+    @Override
+    public boolean hasCallerData() {
+        return delegate.hasCallerData();
+    }
+
+    @Override
+    public Marker getMarker() {
+        return delegate.getMarker();
+    }
+
+    @Override
+    public List<Marker> getMarkerList() {
+        return delegate.getMarkerList();
+    }
+
+    @Override
+    public Map<String, String> getMDCPropertyMap() {
+        return delegate.getMDCPropertyMap();
+    }
+
+    @Override
+    @Deprecated
+    @SuppressWarnings("deprecation")
+    public Map<String, String> getMdc() {
+        return delegate.getMdc();
+    }
+
+    @Override
+    public long getTimeStamp() {
+        return delegate.getTimeStamp();
+    }
+
+    @Override
+    public int getNanoseconds() {
+        return delegate.getNanoseconds();
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return delegate.getSequenceNumber();
+    }
+
+    @Override
+    public List<KeyValuePair> getKeyValuePairs() {
+        return delegate.getKeyValuePairs();
+    }
+
+    @Override
+    public void prepareForDeferredProcessing() {
+        delegate.prepareForDeferredProcessing();
+    }
+}

--- a/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/MaskedLoggingEvent.java
+++ b/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/MaskedLoggingEvent.java
@@ -37,7 +37,6 @@ public class MaskedLoggingEvent implements ILoggingEvent {
 
     @Override
     public Object[] getArgumentArray() {
-        // повертаємо пустий масив, щоб енкодери не пробували форматувати старі аргументи
         return new Object[0];
     }
 

--- a/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppender.java
+++ b/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppender.java
@@ -1,0 +1,141 @@
+package com.icthh.xm.commons.logging.aop;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import lombok.Setter;
+
+/**
+ * Console appender that performs security masking of log messages based on configured keywords.
+ * <p>
+ * If a log message contains any of the defined keywords (case-insensitive),
+ * the entire message will be replaced with the configured {@code replacementMessage}.
+ * This prevents sensitive information (PIN, PUK, passwords, tokens, etc.)
+ * from appearing in logs.
+ * <p>
+ * Typical configuration (in logback-spring.xml):
+ *
+ * <pre>{@code
+ * <appender name="MASKED_CONSOLE" class="com.icthh.xm.commons.logging.aop.SecurityMaskingConsoleAppender">
+ *     <keywords>pin=, puk:, password, authToken</keywords>
+ *     <replacementMessage>[MASKED]</replacementMessage>
+ *     <encoder>
+ *         <pattern>%msg%n</pattern>
+ *     </encoder>
+ * </appender>
+ * }</pre>
+ *
+ * This appender wraps the original {@link ILoggingEvent} into {@link MaskedLoggingEvent}
+ * when masking is required.
+ */
+public class SecurityMaskingConsoleAppender extends ConsoleAppender<ILoggingEvent> {
+
+    /**
+     * List of case-insensitive keywords which, if found in a log message,
+     * will trigger masking.
+     */
+    private final List<String> keywords = new ArrayList<>();
+
+    /**
+     * Message that will replace the original log message when masking is applied.
+     * Must be configured explicitly.
+     * -- SETTER --
+     *  Sets the message that will be logged instead of the original message
+     *  when masking is triggered.
+     *
+     * @param replacementMessage replacement text (can be null if masking is disabled)
+
+     */
+    @Setter
+    private String replacementMessage;
+
+    /**
+     * Adds a single keyword to the internal keyword list.
+     * Keywords are stored in lowercase to allow case-insensitive comparison.
+     *
+     * @param keyword keyword to add (ignored if null or blank)
+     */
+    public void addKeyword(String keyword) {
+        if (keyword != null && !keyword.isBlank()) {
+            keywords.add(keyword.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    /**
+     * Configures masking keywords from a comma-separated string..
+     * Example: {@code "pin=, puk:, password"}
+     *
+     * @param keywords comma-separated keywords list.
+     */
+    public void setKeywords(String keywords) {
+        if (keywords == null || keywords.isBlank()) {
+            return;
+        }
+
+        for (String k : keywords.split(",")) {
+            addKeyword(k.trim());
+        }
+    }
+
+    /**
+     * Wraps the incoming event in {@link MaskedLoggingEvent} if masking is needed.
+     * Otherwise, returns the original event.
+     *
+     * @param eventObject original logging event
+     */
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        ILoggingEvent toLog = applyMasking(eventObject);
+        super.append(toLog);
+    }
+
+    /**
+     * Applies masking logic to the provided logging event.
+     * This method is extracted for easier unit testing.
+     *
+     * @param original the original event
+     * @return masked event, or original event if no keyword matched
+     */
+    ILoggingEvent applyMasking(ILoggingEvent original) {
+        if (original == null) {
+            return null;
+        }
+
+        String msg = original.getFormattedMessage();
+        if (msg == null) {
+            msg = original.getMessage();
+        }
+
+        if (containsSensitive(msg)) {
+            return new MaskedLoggingEvent(original, replacementMessage);
+        }
+
+        return original;
+    }
+
+    /**
+     * Checks whether the message contains any of the configured keywords.
+     * Comparison is case-insensitive.
+     *
+     * @param msg message to check
+     * @return true if message contains a sensitive keyword
+     */
+    private boolean containsSensitive(String msg) {
+        if (msg == null || keywords.isEmpty()) {
+            return false;
+        }
+
+        String lowerMsg = msg.toLowerCase(Locale.ROOT);
+
+        for (String keyword : keywords) {
+            if (lowerMsg.contains(keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppender.java
+++ b/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppender.java
@@ -93,6 +93,19 @@ public class SecurityMaskingConsoleAppender extends ConsoleAppender<ILoggingEven
     }
 
     /**
+     * Validates configuration on startup and warns when masking keywords are configured
+     * without a usable replacement message, in which case masking stays disabled.
+     */
+    @Override
+    public void start() {
+        if (!keywords.isEmpty() && !hasReplacementMessage()) {
+            addWarn("Security masking keywords are configured but replacementMessage is missing or blank; "
+                + "masking is disabled until a valid replacementMessage is provided.");
+        }
+        super.start();
+    }
+
+    /**
      * Applies masking logic to the provided logging event.
      * This method is extracted for easier unit testing.
      *
@@ -102,6 +115,10 @@ public class SecurityMaskingConsoleAppender extends ConsoleAppender<ILoggingEven
     ILoggingEvent applyMasking(ILoggingEvent original) {
         if (original == null) {
             return null;
+        }
+
+        if (!hasReplacementMessage()) {
+            return original;
         }
 
         String msg = original.getFormattedMessage();
@@ -114,6 +131,15 @@ public class SecurityMaskingConsoleAppender extends ConsoleAppender<ILoggingEven
         }
 
         return original;
+    }
+
+    /**
+     * Checks whether a usable replacement message is configured.
+     *
+     * @return true if replacementMessage is present and not blank
+     */
+    private boolean hasReplacementMessage() {
+        return replacementMessage != null && !replacementMessage.isBlank();
     }
 
     /**

--- a/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
+++ b/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
@@ -100,6 +100,17 @@ public class SecurityMaskingConsoleAppenderUnitTest {
     }
 
     @Test
+    public void shouldNotMaskWhenReplacementMessageMissing() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("pin=");
+
+        LoggingEvent event = newEvent("test.no.replacement", "pin=0000");
+        var result = appender.applyMasking(event);
+
+        assertThat(result.getFormattedMessage(), is("pin=0000"));
+    }
+
+    @Test
     public void shouldReplaceMessageIgnoringCaseForPatternEncoder() {
         SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
         appender.setKeywords("pin=");

--- a/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
+++ b/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
@@ -1,0 +1,91 @@
+package com.icthh.xm.commons.logging.aop;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SecurityMaskingConsoleAppender} that verify
+ * masking behavior for log messages containing sensitive keywords.
+ */
+public class SecurityMaskingConsoleAppenderUnitTest {
+
+    private static final String REPLACEMENT =
+            "this log was removed due to potential security breach";
+
+    private LoggingEvent newEvent(String loggerName, String msg) {
+        LoggerContext ctx = new LoggerContext();
+        LoggingEvent event = new LoggingEvent();
+        event.setLoggerContext(ctx);
+        event.setLoggerName(loggerName);
+        event.setLevel(Level.INFO);
+        event.setMessage(msg);
+        return event;
+    }
+
+    @Test
+    public void shouldReplaceMessageForPatternEncoderWhenContainsKeyword() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("keyword:, keyword=");
+        appender.setReplacementMessage(REPLACEMENT);
+
+        LoggingEvent safe = newEvent("test.pattern.logger", "safe message");
+        var safeResult = appender.applyMasking(safe);
+
+        assertThat(safeResult.getFormattedMessage(), is("safe message"));
+
+        LoggingEvent sensitive = newEvent("test.pattern.logger", "keyword: 1234");
+        var masked = appender.applyMasking(sensitive);
+
+        assertThat(masked.getFormattedMessage(), is(REPLACEMENT));
+        assertThat(masked.getFormattedMessage(), not(containsString("keyword: 1234")));
+    }
+
+    @Test
+    public void shouldReplaceMessageForJsonEncoderWhenContainsKeyword() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("keyword:, keyword=");
+        appender.setReplacementMessage(REPLACEMENT);
+
+        LoggingEvent safe = newEvent("test.json.logger", "safe json");
+        var safeResult = appender.applyMasking(safe);
+
+        assertThat(safeResult.getFormattedMessage(), containsString("safe json"));
+        assertThat(safeResult.getFormattedMessage(), not(containsString(REPLACEMENT)));
+
+        LoggingEvent sensitive = newEvent("test.json.logger", "keyword=qwerty");
+        var masked = appender.applyMasking(sensitive);
+
+        assertThat(masked.getFormattedMessage(), containsString(REPLACEMENT));
+        assertThat(masked.getFormattedMessage(), not(containsString("keyword=qwerty")));
+    }
+
+    @Test
+    public void shouldNotMaskWhenNoKeywordsConfigured() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+
+        LoggingEvent event = newEvent("test.no.keyword", "keyword: should stay as is");
+        var result = appender.applyMasking(event);
+
+        assertThat(result.getFormattedMessage(), is("keyword: should stay as is"));
+    }
+
+    @Test
+    public void shouldReplaceMessageIgnoringCaseForPatternEncoder() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("pin=");
+        appender.setReplacementMessage(REPLACEMENT);
+
+        LoggingEvent event = newEvent("test.pattern.ignorecase", "PIN=0000");
+        var result = appender.applyMasking(event);
+
+        assertThat(result.getFormattedMessage(), is(REPLACEMENT));
+        assertThat(result.getFormattedMessage(), not(containsString("PIN=0000")));
+    }
+}

--- a/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
+++ b/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
@@ -8,6 +8,10 @@ import static org.hamcrest.Matchers.not;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import net.logstash.logback.encoder.LogstashEncoder;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,6 +30,9 @@ public class SecurityMaskingConsoleAppenderUnitTest {
         event.setLoggerName(loggerName);
         event.setLevel(Level.INFO);
         event.setMessage(msg);
+        event.setThreadName(Thread.currentThread().getName());
+        event.setTimeStamp(System.currentTimeMillis());
+        event.setMDCPropertyMap(Collections.emptyMap());
         return event;
     }
 
@@ -49,21 +56,37 @@ public class SecurityMaskingConsoleAppenderUnitTest {
 
     @Test
     public void shouldReplaceMessageForJsonEncoderWhenContainsKeyword() {
+        LoggerContext ctx = new LoggerContext();
+
+        LogstashEncoder encoder = new LogstashEncoder();
+        encoder.setContext(ctx);
+        encoder.start();
+
         SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setContext(ctx);
         appender.setKeywords("keyword:, keyword=");
         appender.setReplacementMessage(REPLACEMENT);
+        appender.setEncoder(encoder);
 
-        LoggingEvent safe = newEvent("test.json.logger", "safe json");
-        var safeResult = appender.applyMasking(safe);
+        String safeJson = appendAndCapture(appender, newEvent("test.json.logger", "safe json"));
+        assertThat(safeJson, containsString("safe json"));
+        assertThat(safeJson, not(containsString(REPLACEMENT)));
 
-        assertThat(safeResult.getFormattedMessage(), containsString("safe json"));
-        assertThat(safeResult.getFormattedMessage(), not(containsString(REPLACEMENT)));
+        String maskedJson = appendAndCapture(appender, newEvent("test.json.logger", "keyword=qwerty"));
+        assertThat(maskedJson, containsString(REPLACEMENT));
+        assertThat(maskedJson, not(containsString("keyword=qwerty")));
+    }
 
-        LoggingEvent sensitive = newEvent("test.json.logger", "keyword=qwerty");
-        var masked = appender.applyMasking(sensitive);
-
-        assertThat(masked.getFormattedMessage(), containsString(REPLACEMENT));
-        assertThat(masked.getFormattedMessage(), not(containsString("keyword=qwerty")));
+    private String appendAndCapture(SecurityMaskingConsoleAppender appender, LoggingEvent event) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        appender.start();
+        appender.setOutputStream(out);
+        try {
+            appender.doAppend(event);
+        } finally {
+            appender.stop();
+        }
+        return out.toString(StandardCharsets.UTF_8);
     }
 
     @Test


### PR DESCRIPTION
# **Add security masking logging appender**

## **Summary**

Introduces a reusable `SecurityMaskingConsoleAppender` and a comprehensive set of tests to enable **security-aware console logging** with configurable keyword masking at the library level.

The appender detects sensitive data (PIN, PUK, passwords, tokens, etc.) in log messages and replaces them with a safe replacement message.

---

## **Changes**

### ✅ Added

* `SecurityMaskingConsoleAppender` implementation in **xm-commons-logging**

  * wraps `ILoggingEvent` into `MaskedLoggingEvent` when message contains sensitive keywords
  * case-insensitive keyword matching
  * configurable via comma-separated keyword list
  * configurable replacement message
* `MaskedLoggingEvent` wrapper class
* Full `SecurityMaskingConsoleAppenderUnitTest` suite covering:

  * pattern encoder masking
  * JSON encoder masking
  * no-keyword scenario
  * case-insensitive detection
* Javadoc describing masking semantics and intended usage.

---

## **Why**

To prevent accidental leakage of sensitive data (PIN, PUK, passwords, tokens, etc.) in logs produced by microservices that depend on `xm-commons-logging`.

Centralizing this logic in a shared library ensures:

* consistent masking across all services
* no duplicated appender implementations
* easy adoption by simply referencing the new appender in `logback-spring.xml`.

---

## **Configuration / Usage Example**

### **1) Pattern encoder example**

```xml
<appender name="MASKED_CONSOLE"
          class="com.icthh.xm.commons.logging.aop.SecurityMaskingConsoleAppender">
    <keywords>${LOGBACK_SECURITY_MASKING_KEYWORDS:-pin=,puk:,password,authToken}</keywords>
    <replacementMessage>${LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE:-this log was removed due to potential security breach}</replacementMessage>
    <encoder>
        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
    </encoder>
</appender>

<root level="INFO">
    <appender-ref ref="MASKED_CONSOLE"/>
</root>
```

---

### **2) JSON Logstash encoder example**

```xml
<appender name="MASKED_CONSOLE_JSON"
          class="com.icthh.xm.commons.logging.aop.SecurityMaskingConsoleAppender">
    <keywords>${LOGBACK_SECURITY_MASKING_KEYWORDS:-pin=,puk:,password,authToken}</keywords>
    <replacementMessage>${LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE:-this log was removed due to potential security breach}</replacementMessage>
    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
</appender>
```

---

## **Environment variables**

| Variable                                       | Description                                                                                                    |
| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| `LOGBACK_SECURITY_MASKING_KEYWORDS`            | Comma-separated keywords to mask (e.g. `password,token,ssn,pin=`).                                             |
| `LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE` | Replacement text for masked log messages (default: *"this log was removed due to potential security breach"*). |

---

## **Important**

➡️ **Masking is disabled by default.**
If `LOGBACK_SECURITY_MASKING_KEYWORDS` is empty or not provided, the appender behaves as a **no-op** and leaves messages unchanged.

Masking becomes active only after **explicit configuration**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added log masking for console output when configured sensitive keywords are detected.
  * Added support for customizable replacement text and comma-separated keyword configuration.
  * Preserves original logs when no keywords are set or no sensitive content is found.

* **Bug Fixes**
  * Prevents original log arguments from being exposed in masked messages.
  * Masking now works case-insensitively for matching keywords.

* **Tests**
  * Added coverage for pattern and JSON log formats, no-keyword behavior, and case-insensitive masking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->