### PR TITLE
feat(logging): add security masking appender

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "4.1.15"//detectSemVersion()
+version = "4.1.22"//detectSemVersion()
 
 logger.lifecycle("Project  version: $version")
 

--- a/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/MaskedLoggingEvent.java
+++ b/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/MaskedLoggingEvent.java
@@ -1,0 +1,119 @@
+package com.icthh.xm.commons.logging.aop;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
+
+import java.util.List;
+import java.util.Map;
+
+public class MaskedLoggingEvent implements ILoggingEvent {
+
+    private final ILoggingEvent delegate;
+    private final String maskedMessage;
+
+    public MaskedLoggingEvent(ILoggingEvent delegate, String maskedMessage) {
+        this.delegate = delegate;
+        this.maskedMessage = maskedMessage;
+    }
+
+    @Override
+    public String getThreadName() {
+        return delegate.getThreadName();
+    }
+
+    @Override
+    public Level getLevel() {
+        return delegate.getLevel();
+    }
+
+    @Override
+    public String getMessage() {
+        return maskedMessage;
+    }
+
+    @Override
+    public Object[] getArgumentArray() {
+        return new Object[0];
+    }
+
+    @Override
+    public String getFormattedMessage() {
+        return maskedMessage;
+    }
+
+    @Override
+    public String getLoggerName() {
+        return delegate.getLoggerName();
+    }
+
+    @Override
+    public LoggerContextVO getLoggerContextVO() {
+        return delegate.getLoggerContextVO();
+    }
+
+    @Override
+    public IThrowableProxy getThrowableProxy() {
+        return delegate.getThrowableProxy();
+    }
+
+    @Override
+    public StackTraceElement[] getCallerData() {
+        return delegate.getCallerData();
+    }
+
+    @Override
+    public boolean hasCallerData() {
+        return delegate.hasCallerData();
+    }
+
+    @Override
+    public Marker getMarker() {
+        return delegate.getMarker();
+    }
+
+    @Override
+    public List<Marker> getMarkerList() {
+        return delegate.getMarkerList();
+    }
+
+    @Override
+    public Map<String, String> getMDCPropertyMap() {
+        return delegate.getMDCPropertyMap();
+    }
+
+    @Override
+    @Deprecated
+    @SuppressWarnings("deprecation")
+    public Map<String, String> getMdc() {
+        return delegate.getMdc();
+    }
+
+    @Override
+    public long getTimeStamp() {
+        return delegate.getTimeStamp();
+    }
+
+    @Override
+    public int getNanoseconds() {
+        return delegate.getNanoseconds();
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return delegate.getSequenceNumber();
+    }
+
+    @Override
+    public List<KeyValuePair> getKeyValuePairs() {
+        return delegate.getKeyValuePairs();
+    }
+
+    @Override
+    public void prepareForDeferredProcessing() {
+        delegate.prepareForDeferredProcessing();
+    }
+}

--- a/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppender.java
+++ b/xm-commons-logging/src/main/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppender.java
@@ -1,0 +1,167 @@
+package com.icthh.xm.commons.logging.aop;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import lombok.Setter;
+
+/**
+ * Console appender that performs security masking of log messages based on configured keywords.
+ * <p>
+ * If a log message contains any of the defined keywords (case-insensitive),
+ * the entire message will be replaced with the configured {@code replacementMessage}.
+ * This prevents sensitive information (PIN, PUK, passwords, tokens, etc.)
+ * from appearing in logs.
+ * <p>
+ * Typical configuration (in logback-spring.xml):
+ *
+ * <pre>{@code
+ * <appender name="MASKED_CONSOLE" class="com.icthh.xm.commons.logging.aop.SecurityMaskingConsoleAppender">
+ *     <keywords>pin=, puk:, password, authToken</keywords>
+ *     <replacementMessage>[MASKED]</replacementMessage>
+ *     <encoder>
+ *         <pattern>%msg%n</pattern>
+ *     </encoder>
+ * </appender>
+ * }</pre>
+ *
+ * This appender wraps the original {@link ILoggingEvent} into {@link MaskedLoggingEvent}
+ * when masking is required.
+ */
+public class SecurityMaskingConsoleAppender extends ConsoleAppender<ILoggingEvent> {
+
+    /**
+     * List of case-insensitive keywords which, if found in a log message,
+     * will trigger masking.
+     */
+    private final List<String> keywords = new ArrayList<>();
+
+    /**
+     * Message that will replace the original log message when masking is applied.
+     * Must be configured explicitly.
+     * -- SETTER --
+     *  Sets the message that will be logged instead of the original message
+     *  when masking is triggered.
+     *
+     * @param replacementMessage replacement text (can be null if masking is disabled)
+
+     */
+    @Setter
+    private String replacementMessage;
+
+    /**
+     * Adds a single keyword to the internal keyword list.
+     * Keywords are stored in lowercase to allow case-insensitive comparison.
+     *
+     * @param keyword keyword to add (ignored if null or blank)
+     */
+    public void addKeyword(String keyword) {
+        if (keyword != null && !keyword.isBlank()) {
+            keywords.add(keyword.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    /**
+     * Configures masking keywords from a comma-separated string..
+     * Example: {@code "pin=, puk:, password"}
+     *
+     * @param keywords comma-separated keywords list.
+     */
+    public void setKeywords(String keywords) {
+        if (keywords == null || keywords.isBlank()) {
+            return;
+        }
+
+        for (String k : keywords.split(",")) {
+            addKeyword(k.trim());
+        }
+    }
+
+    /**
+     * Wraps the incoming event in {@link MaskedLoggingEvent} if masking is needed.
+     * Otherwise, returns the original event.
+     *
+     * @param eventObject original logging event
+     */
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        ILoggingEvent toLog = applyMasking(eventObject);
+        super.append(toLog);
+    }
+
+    /**
+     * Validates configuration on startup and warns when masking keywords are configured
+     * without a usable replacement message, in which case masking stays disabled.
+     */
+    @Override
+    public void start() {
+        if (!keywords.isEmpty() && !hasReplacementMessage()) {
+            addWarn("Security masking keywords are configured but replacementMessage is missing or blank; "
+                + "masking is disabled until a valid replacementMessage is provided.");
+        }
+        super.start();
+    }
+
+    /**
+     * Applies masking logic to the provided logging event.
+     * This method is extracted for easier unit testing.
+     *
+     * @param original the original event
+     * @return masked event, or original event if no keyword matched
+     */
+    ILoggingEvent applyMasking(ILoggingEvent original) {
+        if (original == null) {
+            return null;
+        }
+
+        if (!hasReplacementMessage()) {
+            return original;
+        }
+
+        String msg = original.getFormattedMessage();
+        if (msg == null) {
+            msg = original.getMessage();
+        }
+
+        if (containsSensitive(msg)) {
+            return new MaskedLoggingEvent(original, replacementMessage);
+        }
+
+        return original;
+    }
+
+    /**
+     * Checks whether a usable replacement message is configured.
+     *
+     * @return true if replacementMessage is present and not blank
+     */
+    private boolean hasReplacementMessage() {
+        return replacementMessage != null && !replacementMessage.isBlank();
+    }
+
+    /**
+     * Checks whether the message contains any of the configured keywords.
+     * Comparison is case-insensitive.
+     *
+     * @param msg message to check
+     * @return true if message contains a sensitive keyword
+     */
+    private boolean containsSensitive(String msg) {
+        if (msg == null || keywords.isEmpty()) {
+            return false;
+        }
+
+        String lowerMsg = msg.toLowerCase(Locale.ROOT);
+
+        for (String keyword : keywords) {
+            if (lowerMsg.contains(keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
+++ b/xm-commons-logging/src/test/java/com/icthh/xm/commons/logging/aop/SecurityMaskingConsoleAppenderUnitTest.java
@@ -1,0 +1,125 @@
+package com.icthh.xm.commons.logging.aop;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SecurityMaskingConsoleAppender} that verify
+ * masking behavior for log messages containing sensitive keywords.
+ */
+public class SecurityMaskingConsoleAppenderUnitTest {
+
+    private static final String REPLACEMENT =
+        "this log was removed due to potential security breach";
+
+    private LoggingEvent newEvent(String loggerName, String msg) {
+        LoggerContext ctx = new LoggerContext();
+        LoggingEvent event = new LoggingEvent();
+        event.setLoggerContext(ctx);
+        event.setLoggerName(loggerName);
+        event.setLevel(Level.INFO);
+        event.setMessage(msg);
+        event.setThreadName(Thread.currentThread().getName());
+        event.setTimeStamp(System.currentTimeMillis());
+        event.setMDCPropertyMap(Collections.emptyMap());
+        return event;
+    }
+
+    @Test
+    public void shouldReplaceMessageForPatternEncoderWhenContainsKeyword() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("keyword:, keyword=");
+        appender.setReplacementMessage(REPLACEMENT);
+
+        LoggingEvent safe = newEvent("test.pattern.logger", "safe message");
+        var safeResult = appender.applyMasking(safe);
+
+        assertThat(safeResult.getFormattedMessage(), is("safe message"));
+
+        LoggingEvent sensitive = newEvent("test.pattern.logger", "keyword: 1234");
+        var masked = appender.applyMasking(sensitive);
+
+        assertThat(masked.getFormattedMessage(), is(REPLACEMENT));
+        assertThat(masked.getFormattedMessage(), not(containsString("keyword: 1234")));
+    }
+
+    @Test
+    public void shouldReplaceMessageForJsonEncoderWhenContainsKeyword() {
+        LoggerContext ctx = new LoggerContext();
+
+        LogstashEncoder encoder = new LogstashEncoder();
+        encoder.setContext(ctx);
+        encoder.start();
+
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setContext(ctx);
+        appender.setKeywords("keyword:, keyword=");
+        appender.setReplacementMessage(REPLACEMENT);
+        appender.setEncoder(encoder);
+
+        String safeJson = appendAndCapture(appender, newEvent("test.json.logger", "safe json"));
+        assertThat(safeJson, containsString("safe json"));
+        assertThat(safeJson, not(containsString(REPLACEMENT)));
+
+        String maskedJson = appendAndCapture(appender, newEvent("test.json.logger", "keyword=qwerty"));
+        assertThat(maskedJson, containsString(REPLACEMENT));
+        assertThat(maskedJson, not(containsString("keyword=qwerty")));
+    }
+
+    private String appendAndCapture(SecurityMaskingConsoleAppender appender, LoggingEvent event) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        appender.start();
+        appender.setOutputStream(out);
+        try {
+            appender.doAppend(event);
+        } finally {
+            appender.stop();
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void shouldNotMaskWhenNoKeywordsConfigured() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+
+        LoggingEvent event = newEvent("test.no.keyword", "keyword: should stay as is");
+        var result = appender.applyMasking(event);
+
+        assertThat(result.getFormattedMessage(), is("keyword: should stay as is"));
+    }
+
+    @Test
+    public void shouldNotMaskWhenReplacementMessageMissing() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("pin=");
+
+        LoggingEvent event = newEvent("test.no.replacement", "pin=0000");
+        var result = appender.applyMasking(event);
+
+        assertThat(result.getFormattedMessage(), is("pin=0000"));
+    }
+
+    @Test
+    public void shouldReplaceMessageIgnoringCaseForPatternEncoder() {
+        SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+        appender.setKeywords("pin=");
+        appender.setReplacementMessage(REPLACEMENT);
+
+        LoggingEvent event = newEvent("test.pattern.ignorecase", "PIN=0000");
+        var result = appender.applyMasking(event);
+
+        assertThat(result.getFormattedMessage(), is(REPLACEMENT));
+        assertThat(result.getFormattedMessage(), not(containsString("PIN=0000")));
+    }
+}


### PR DESCRIPTION
### Summary
Adds a reusable `SecurityMaskingConsoleAppender` to `xm-commons-logging` for security-aware console logging.  
The appender masks log messages that contain sensitive keywords such as PIN, PUK, passwords, tokens, and similar values.

### Changes
- Added `SecurityMaskingConsoleAppender` for keyword-based masking
- Added `MaskedLoggingEvent` wrapper for masked console output
- Added tests for pattern encoder, JSON encoder, no-keyword, and case-insensitive masking scenarios
- Added Javadoc describing masking behavior and intended usage

### Why
To centralize security masking in a shared library and prevent accidental leakage of sensitive data in console logs across dependent microservices.

### Usage
Configure the appender in `logback-spring.xml` and provide:
- `LOGBACK_SECURITY_MASKING_KEYWORDS`
- `LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE`

### Notes
- Masking is disabled by default
- If no keywords are configured, the appender behaves as a no-op
- This change is backward compatible and does not require consumer code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable security masking for console logs.
  * Sensitive messages matching configured keywords are replaced with a safe placeholder, including structured JSON logs.
  * Keyword matching is case-insensitive, and original log arguments are suppressed when masking is applied.

* **Bug Fixes**
  * Prevented sensitive content from appearing in supported console log output.

* **Chores**
  * Updated the project version from 4.1.15 to 4.1.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->