### PR TITLE
Disable kafka metric con log

### DIFF
--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,6 +1,6 @@
 import java.util.regex.Pattern
 
-version = "5.0.24"//detectSemVersion()
+version = "5.0.25"//detectSemVersion()
 
 logger.lifecycle("Project  version: $version")
 

--- a/xm-commons-metric/src/main/java/com/icthh/xm/commons/metric/KafkaMetrics.java
+++ b/xm-commons-metric/src/main/java/com/icthh/xm/commons/metric/KafkaMetrics.java
@@ -52,7 +52,7 @@ public class KafkaMetrics implements MeterBinder {
                         describeTopicsOptions);
                     Map<String, TopicDescription> topicDescriptionMap = describeTopicsResult.allTopicNames().get();
                     boolean monitoringResult = nonNull(topicDescriptionMap);
-                    log.info("Connection to Kafka topics is {}, time: {}", monitoringResult, executionTime.getTime());
+                    log.debug("Connection to Kafka topics is {}, time: {}", monitoringResult, executionTime.getTime());
                     return monitoringResult;
                 } catch (Exception e) {
                     log.warn("Exception when try connect to kafka topics: {}, exception: {}, time: {}", metricTopics,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 5.0.25.

* **Refactor**
  * Reduced routine Kafka connection success messages to debug-level logging, helping keep standard logs less noisy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->